### PR TITLE
Switching tests to XUnit & Fixing Bug

### DIFF
--- a/Metrics.NET.SignalFX.UnitTest/Metrics.NET.SignalFX.UnitTest.csproj
+++ b/Metrics.NET.SignalFX.UnitTest/Metrics.NET.SignalFX.UnitTest.csproj
@@ -1,101 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{29D75078-9E6C-48D0-9034-8084BEC6574D}</ProjectGuid>
+    <ProjectGuid>{C7446CAE-8ABD-48BA-9A9A-242E00826044}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Metrics.NET.SignalFX.UnitTest</RootNamespace>
     <AssemblyName>Metrics.NET.SignalFX.UnitTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
     <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
+    <OutputPath>bin\Release</OutputPath>
     <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="System" />
     <Reference Include="Google.ProtocolBuffers">
-      <HintPath>..\Metrics.NET.SignalFX\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.dll</HintPath>
+      <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.ProtocolBuffers.Serialization">
+      <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
     </Reference>
     <Reference Include="Metrics">
-      <HintPath>..\Metrics.NET.SignalFX\packages\Metrics.NET.0.2.14\lib\net45\Metrics.dll</HintPath>
+      <HintPath>..\packages\Metrics.NET.0.2.14\lib\net45\Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
+    <Reference Include="xunit">
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Fakes\FakeSignalFxReporter.cs" />
     <Compile Include="SignalFxReportTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Metrics.NET.SignalFX\Metrics.NET.SignalFX.csproj">
-      <Project>{734125d8-6d99-4af6-afcd-9836df09a1f2}</Project>
-      <Name>Metrics.NET.SignalFX</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="protos\google\protobuf\csharp_options.proto" />
-    <None Include="protos\google\protobuf\descriptor.proto" />
-    <None Include="protos\tutorial\addressbook.proto" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="CHANGES.txt" />
-    <Content Include="licenses\license.txt" />
-    <Content Include="licenses\protoc-license.txt" />
-  </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -104,4 +60,14 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Metrics.NET.SignalFX\Metrics.NET.SignalFX.csproj">
+      <Project>{734125d8-6d99-4af6-afcd-9836df09a1f2}</Project>
+      <Name>Metrics.NET.SignalFX</Name>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/Metrics.NET.SignalFX.UnitTest/SignalFxReportTests.cs
+++ b/Metrics.NET.SignalFX.UnitTest/SignalFxReportTests.cs
@@ -2,29 +2,24 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Metrics.Core;
+using Xunit;
 using Metrics.NET.SignalFX.UnitTest.Fakes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Metrics.SignalFx;
 
 namespace Metrics.NET.SignalFX.UnitTest
 {
-    [TestClass]
     public class SignalFxReportTests
     {
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
+        [Fact]
         public void AddMetrics_TestEqualsGetsEscaped()
         {
             var context = new DefaultMetricsContext();
             var sender = new FakeSignalFxReporter();
             var report = new SignalFxReport(
-                sender, 
-                "FakeApiKey",
-                new Dictionary<string, string>
-                {
-                    {"System", "UnitTests"}
+                             sender, 
+                             "FakeApiKey",
+                             new Dictionary<string, string> {
+                    { "System", "UnitTests" }
                 });
 
             var tags = new MetricTags("test\\=string=test\\value");
@@ -35,14 +30,14 @@ namespace Metrics.NET.SignalFX.UnitTest
             var source = new CancellationTokenSource();
             report.RunReport(context.DataProvider.CurrentMetricsData, () => new HealthStatus(), source.Token);
 
-            Assert.AreEqual(1, sender.Count);
+            Assert.Equal(1, sender.Count);
             var message = sender[0];
 
             var dp = message.DatapointsList.FirstOrDefault(datapoint => datapoint.DimensionsList.Any(dimension => dimension.Key == "test=string"));
-            Assert.IsNotNull(dp);
+            Assert.NotNull(dp);
 
             var dm = dp.DimensionsList.FirstOrDefault(dimension => dimension.Key == "test=string");
-            Assert.AreEqual("testvalue", dm.Value);
+            Assert.Equal("testvalue", dm.Value);
         }
     }
 }

--- a/Metrics.NET.SignalFX.UnitTest/packages.config
+++ b/Metrics.NET.SignalFX.UnitTest/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
   <package id="Metrics.NET" version="0.2.14" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/Metrics.NET.SignalFX.sln
+++ b/Metrics.NET.SignalFX.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
+# Visual Studio 2012
 VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Metrics.NET.SignalFX", "Metrics.NET.SignalFX\Metrics.NET.SignalFX.csproj", "{734125D8-6D99-4AF6-AFCD-9836DF09A1F2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Metrics.NET.SignalFX.UnitTest", "Metrics.NET.SignalFX.UnitTest\Metrics.NET.SignalFX.UnitTest.csproj", "{29D75078-9E6C-48D0-9034-8084BEC6574D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Metrics.NET.SignalFX.UnitTest", "Metrics.NET.SignalFX.UnitTest\Metrics.NET.SignalFX.UnitTest.csproj", "{C7446CAE-8ABD-48BA-9A9A-242E00826044}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,14 @@ Global
 		{734125D8-6D99-4AF6-AFCD-9836DF09A1F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{734125D8-6D99-4AF6-AFCD-9836DF09A1F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{734125D8-6D99-4AF6-AFCD-9836DF09A1F2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{29D75078-9E6C-48D0-9034-8084BEC6574D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{29D75078-9E6C-48D0-9034-8084BEC6574D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{29D75078-9E6C-48D0-9034-8084BEC6574D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{29D75078-9E6C-48D0-9034-8084BEC6574D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7446CAE-8ABD-48BA-9A9A-242E00826044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7446CAE-8ABD-48BA-9A9A-242E00826044}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7446CAE-8ABD-48BA-9A9A-242E00826044}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7446CAE-8ABD-48BA-9A9A-242E00826044}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18137FCB-3776-4394-B46F-3F46AFC80C9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18137FCB-3776-4394-B46F-3F46AFC80C9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18137FCB-3776-4394-B46F-3F46AFC80C9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18137FCB-3776-4394-B46F-3F46AFC80C9A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Metrics.NET.SignalFX/SignalFxReporter.cs
+++ b/Metrics.NET.SignalFX/SignalFxReporter.cs
@@ -31,6 +31,8 @@ namespace Metrics.SignalFx
                 using (var rs = req.GetRequestStream())
                 {
                     msg.WriteTo(rs);
+                    // flush the message before disposing
+                    rs.Flush();
                 }
 
                 using (var resp = (HttpWebResponse)req.GetResponse())


### PR DESCRIPTION
Fixing Bug in Reporter when HTTP take longer than the .NET runtime (might happen a lot):

Metrics: Unhandled exception in Metrics.NET Library System.Net.WebException: The request was aborted: The request was canceled. ---> System.IO.IOException: Cannot close stream until all bytes are written.
at System.Net.ConnectStream.CloseInternal(Boolean internalCall, Boolean aborting)
 --- End of inner exception stack trace ---
 at System.Net.ConnectStream.CloseInternal(Boolean internalCall, Boolean aborting)
 at System.Net.ConnectStream.System.Net.ICloseEx.CloseEx(CloseExState closeState)
 at System.Net.ConnectStream.Dispose(Boolean disposing)
 at System.IO.Stream.Close()
 at Metrics.SignalFx.SignalFxReporter.send(DataPointUploadMessage msg) 