### PR TITLE
ReportOnChanged Metrics

### DIFF
--- a/Metrics.NET.SignalFX/Extensions/TaggedMetricContext.cs
+++ b/Metrics.NET.SignalFX/Extensions/TaggedMetricContext.cs
@@ -5,6 +5,7 @@ namespace Metrics.Core
 {
     public class TaggedMetricsContext : BaseMetricsContext, MetricsContext
     {
+
         public TaggedMetricsContext()
             : this(string.Empty) { }
 
@@ -12,10 +13,54 @@ namespace Metrics.Core
             : base(context, new TaggedMetricsRegistry(), new DefaultMetricsBuilder(), () => Clock.Default.UTCDateTime)
         { }
 
+        /// <summary>
+        /// Creates a counter that will report the difference in counts between reporting periods instead of the total count. This
+        /// is useful if you need a distributed counter.
+        /// </summary>
+        /// <see cref="MetricContext.Counter"/>
         public Counter IncrementalCounter(string name, Unit unit, MetricTags tags = default(MetricTags))
         {
-            return this.Advanced.Counter<IncrementalCounter>(Metrics.SignalFX.Extensions.IncrementalCounter.INC_COUNTER_PREFIX + name, 
+            return this.Advanced.Counter<IncrementalCounter>(Metrics.SignalFX.Extensions.IncrementalCounter.INC_COUNTER_PREFIX + name,
                 unit, () => new IncrementalCounter(), tags);
+        }
+
+        /// <summary>
+        /// Creates a timer that will only report iff at least one sample has been added since the last time a report was sent.
+        /// </summary>
+        /// <see cref="MetricsContext.Timer"/>
+        public Counter ReportOnUpdateCounter(string name, Unit unit, MetricTags tags = default(MetricTags))
+        {
+            return Counter(TaggedMetricsRegistry.REPORT_ON_UPDATE_PREFIX + name, unit, tags);
+        }
+
+        /// <summary>
+        /// Creates a timer that will only report iff at least one sample has been added since the last time a report was sent.
+        /// </summary>
+        /// <see cref="MetricsContext.Timer"/>
+        public Timer ReportOnUpdateTimer(string name, Unit unit,
+            SamplingType samplingType = SamplingType.FavourRecent,
+            TimeUnit rateUnit = TimeUnit.Seconds, TimeUnit durationUnit = TimeUnit.Milliseconds,
+            MetricTags tags = default(MetricTags))
+        {
+            return Timer(TaggedMetricsRegistry.REPORT_ON_UPDATE_PREFIX + name, unit, samplingType, rateUnit, durationUnit, tags);
+        }
+
+        /// <summary>
+        /// Creates a meter that will only report iff at least one sample has been added since the last time a report was sent.
+        /// </summary>
+        /// <see cref="MetricsContext.Meter"/>
+        public Meter ReportOnUpdateMeter(string name, Unit unit, TimeUnit rateUnit = TimeUnit.Seconds, MetricTags tags = default(MetricTags))
+        {
+            return Meter(TaggedMetricsRegistry.REPORT_ON_UPDATE_PREFIX + name, unit, rateUnit, tags);
+        }
+
+        /// <summary>
+        /// Creates a histogram that will only report iff at least one sample has been added since the last time a report was sent.
+        /// </summary>
+        /// <see cref="MetricsContext.Histogram"/>
+        public Histogram ReportOnUpdateHistogram(string name, Unit unit, SamplingType samplingType = SamplingType.FavourRecent, MetricTags tags = default(MetricTags))
+        {
+            return Histogram(TaggedMetricsRegistry.REPORT_ON_UPDATE_PREFIX + name, unit, samplingType, tags);
         }
 
         protected override MetricsContext CreateChildContextInstance(string contextName)

--- a/Metrics.NET.SignalFX/Extensions/TaggedMetricRegistry.cs
+++ b/Metrics.NET.SignalFX/Extensions/TaggedMetricRegistry.cs
@@ -8,8 +8,11 @@ namespace Metrics.Core
 {
     public sealed class TaggedMetricsRegistry : MetricsRegistry
     {
+
+        public static readonly string REPORT_ON_UPDATE_PREFIX = "aaasignalfxreportonupadteprefixaaa";
+
         private class MetricMetaCatalog<TMetric, TValue, TMetricValue>
-            where TValue : MetricValueSource<TMetricValue>
+        where TValue : MetricValueSource<TMetricValue>
         {
             public class MetricMeta
             {
@@ -130,7 +133,7 @@ namespace Metrics.Core
             });
         }
 
-        private string TagName(string name, MetricTags? tags)
+        public static string TagName(string name, MetricTags? tags)
         {
             if (!tags.HasValue)
             {

--- a/Metrics.NET.SignalFX/Properties/AssemblyInfo.cs
+++ b/Metrics.NET.SignalFX/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.2.2.0")]
-[assembly: AssemblyFileVersion("2.2.2.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 [assembly: InternalsVisibleTo("Metrics.NET.SignalFx.UnitTest" )]


### PR DESCRIPTION
In certain cases it is nice to have Meter/Histogram/Counter/Timers that only report
if a sample has been added. TaggedMetricsContext now has support for these
kinds of metrics