### PR TITLE
Change the default host dimension

### DIFF
--- a/Metrics.NET.SignalFX/Properties/AssemblyInfo.cs
+++ b/Metrics.NET.SignalFX/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SignalFx Inc")]
 [assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("Copyright (C) 2015 SignalFx, Inc.")]
+[assembly: AssemblyCopyright("Copyright (C) 2016 SignalFx, Inc.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.4.2.0")]
+[assembly: AssemblyVersion("2.5.0.0")]
 [assembly: InternalsVisibleTo("Metrics.NET.SignalFx.UnitTest" )]

--- a/Metrics.NET.SignalFX/SignalFxReport.cs
+++ b/Metrics.NET.SignalFX/SignalFxReport.cs
@@ -18,7 +18,7 @@ namespace Metrics.SignalFx
         private static readonly char[] EQUAL_SPLIT_CHARS = new char[] { '=' };
         private static readonly string METRIC_DIMENSION = "metric";
         private static readonly string SOURCE_DIMENSION = "source";
-        private static readonly string SF_SOURCE = "sf_source";
+        
         private static readonly HashSet<string> IGNORE_DIMENSIONS = new HashSet<string>();
         static SignalFxReport()
         {

--- a/Metrics.NET.SignalFX/SignalFxReporterBuilder.cs
+++ b/Metrics.NET.SignalFX/SignalFxReporterBuilder.cs
@@ -20,7 +20,12 @@ namespace Metrics.SignalFx
         private static readonly string DEFAULT_URI = "https://ingest.signalfx.com";
         private static readonly int MAX_DATAPOINTS_PER_MESSAGE = 10000;
         private static readonly string INSTANCE_ID_DIMENSION = "InstanceId";
+        private static readonly string HOST_DIMENSION = "host";
 
+        // 'sf_source' was the legacy default host dimension for Windows prior to version 2.5.0.0
+        // of Metrics.NET.SignalFx.dll. Preserve it here in case it's needed by someone.
+        private static readonly string LEGACY_HOST_DIMENSION = "sf_source";
+        
         private MetricsReports reports;
         private string apiToken;
         private TimeSpan interval;
@@ -260,7 +265,7 @@ namespace Metrics.SignalFx
                 }
                 else if (config.SourceType != SourceType.none)
                 {
-                    builder.WithSourceDimension("sf_source");
+                    builder.WithSourceDimension(HOST_DIMENSION);
                 }
 
                 switch (config.SourceType)


### PR DESCRIPTION
Change the default host dimension used by Metrics.NET.SignalFx.dll from
the legacy "sf_source" to "host" to be consistent with other platforms
and so that Windows hosts will show up on the "Hosts" Page.

Retain the legacy dimension as an unused-by-default static string with
appropriate explanation so that it is not lost to the annals of time for
people wanting to go backwards for some unforeseen reason.

Remove an unused copy of the legacy source dimension from the
SignalFxReport object.

Bump the version of Metrics.NET.SignalFx.dll to 2.5.0.0.

Refresh the copyright info for the assembly from 2015 to 2016.